### PR TITLE
Add helper for device selection with MPS priority

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,14 +11,20 @@ from omegaconf import OmegaConf
 from modeling.pipeline import VMemPipeline
 from diffusers.utils import export_to_video
 from navigation import Navigator
-from utils import tensor_to_pil, get_default_intrinsics, load_img_and_K, transform_img_and_K
+from utils import (
+    tensor_to_pil,
+    get_default_intrinsics,
+    load_img_and_K,
+    transform_img_and_K,
+    select_device,
+)
 import os
 import shutil
 
 
 CONFIG_PATH = "configs/inference/inference.yaml"
 CONFIG = OmegaConf.load(CONFIG_PATH)
-DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+DEVICE = select_device()
 MODEL = VMemPipeline(CONFIG, DEVICE)
 NAVIGATORS = []
 

--- a/utils/util.py
+++ b/utils/util.py
@@ -22,6 +22,19 @@ from mpl_toolkits.mplot3d.art3d import Poly3DCollection
 DEFAULT_FOV_RAD = 0.9424777960769379  # 54 degrees by default
 
 
+def select_device() -> torch.device:
+    """Return the best available device.
+
+    Prioritizes Metal Performance Shaders (MPS) on macOS, then CUDA,
+    falling back to CPU.
+    """
+    if torch.backends.mps.is_available():
+        return torch.device("mps")
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+    return torch.device("cpu")
+
+
 
 def get_default_intrinsics(
     fov_rad=DEFAULT_FOV_RAD,


### PR DESCRIPTION
## Summary
- add `select_device` helper in utils
- use this helper in `app.py` to pick CUDA, MPS or CPU automatically

## Testing
- `python -m py_compile app.py utils/util.py && echo "py_compile ok"`

------
https://chatgpt.com/codex/tasks/task_e_687b7b90724c832fb6702cf62e36328e