### PR TITLE
Use selected device with autocast

### DIFF
--- a/app.py
+++ b/app.py
@@ -159,7 +159,7 @@ def get_duration_navigate_video(video: torch.Tensor,
     return base_duration
 
 @spaces.GPU(duration=get_duration_navigate_video)
-@torch.autocast("cuda")
+@torch.autocast(device_type=DEVICE.type)
 @torch.no_grad()
 def navigate_video(
     video: torch.Tensor,

--- a/utils/util.py
+++ b/utils/util.py
@@ -35,6 +35,10 @@ def select_device() -> torch.device:
     return torch.device("cpu")
 
 
+# Chosen device for operations
+DEVICE = select_device()
+
+
 
 def get_default_intrinsics(
     fov_rad=DEFAULT_FOV_RAD,
@@ -708,7 +712,7 @@ def do_sample(
 ):
 
     num_samples = [1, T]
-    with torch.inference_mode(), torch.autocast("cuda"):
+    with torch.inference_mode(), torch.autocast(device_type=DEVICE.type):
 
         additional_model_inputs = {"num_frames": T}
         additional_sampler_inputs = {


### PR DESCRIPTION
## Summary
- use the chosen device when invoking `torch.autocast`
- expose `DEVICE = select_device()` in util helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b7df1c524832fb44bc0b03e9822e5