### PR TITLE
Update docs for MPS install

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ conda activate vmem
 pip install -r requirements.txt
 ```
 
+If you are on macOS with Apple Silicon, install PyTorch with MPS support
+before installing the rest of the requirements:
+
+```bash
+pip3 install torch torchvision --index-url https://download.pytorch.org/whl/cpu
+```
+
+The optional CUDA extension `curope` cannot be built on MPS. If you do not
+have CUDA available you can simply skip compiling it, the code will fall back
+to a slower PyTorch implementation.
+
 
 # :rocket: Usage
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
+# CUDA build of PyTorch (default). If you are on macOS using MPS,
+# install PyTorch manually with:
+#   pip3 install torch torchvision --index-url https://download.pytorch.org/whl/cpu
+# and then run `pip install -r requirements.txt`.
 --extra-index-url https://download.pytorch.org/whl/nightly/cu124
 torch==2.7.0
 torchvision==0.22.0
@@ -40,4 +44,7 @@ wandb
 evo
 open3d
 
+# The following extension requires CUDA. Comment it out if building on macOS
+# or other systems without CUDA. When disabled, a slower PyTorch fallback will
+# be used automatically.
 -e ./extern/CUT3R/src/croco/models/curope


### PR DESCRIPTION
## Summary
- document torch install command for Mac MPS
- explain that curope cannot be compiled on MPS and falls back to a slower version
- add instructions in requirements.txt about CPU-only install

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687b7edeeea4832fba4aaa61c73d21a4