### PR TITLE
Fix patch padding and update autocast usage

### DIFF
--- a/extern/CUT3R/src/dust3r/inference.py
+++ b/extern/CUT3R/src/dust3r/inference.py
@@ -70,7 +70,7 @@ def loss_of_one_batch(
     if symmetrize_batch:
         batch = make_batch_symmetric(batch)
 
-    with torch.cuda.amp.autocast(enabled=not inference):
+    with torch.amp.autocast(device_type="cuda", enabled=not inference):
         if inference:
             output, state_args = model(batch, ret_state=True)
             preds, batch = output.ress, output.views
@@ -80,7 +80,7 @@ def loss_of_one_batch(
             output = model(batch)
             preds, batch = output.ress, output.views
 
-        with torch.cuda.amp.autocast(enabled=False):
+        with torch.amp.autocast(device_type="cuda", enabled=False):
             loss = criterion(batch, preds) if criterion is not None else None
 
     result = dict(views=batch, pred=preds, loss=loss)
@@ -111,7 +111,7 @@ def loss_of_one_batch_tbptt(
     all_preds = []
     all_loss = 0.0
     all_loss_details = {}
-    with torch.cuda.amp.autocast(enabled=not inference):
+    with torch.amp.autocast(device_type="cuda", enabled=not inference):
         with torch.no_grad():
             (feat, pos, shape), (
                 init_state_feat,
@@ -155,7 +155,7 @@ def loss_of_one_batch_tbptt(
                         preds.append(res)
                         all_preds.append({k: v.detach() for k, v in res.items()})
                         chunk.append(batch[i])
-                with torch.cuda.amp.autocast(enabled=False):
+                with torch.amp.autocast(device_type="cuda", enabled=False):
                     loss, loss_details = (
                         criterion(chunk, preds, camera1=batch[0]["camera_pose"])
                         if criterion is not None
@@ -188,7 +188,7 @@ def loss_of_one_batch_tbptt(
                     preds.append(res)
                     all_preds.append({k: v.detach() for k, v in res.items()})
                     chunk.append(batch[i])
-                with torch.cuda.amp.autocast(enabled=False):
+                with torch.amp.autocast(device_type="cuda", enabled=False):
                     loss, loss_details = (
                         criterion(chunk, preds, camera1=batch[0]["camera_pose"])
                         if criterion is not None
@@ -251,7 +251,7 @@ def inference_step(view, state_args, model, device, verbose=True):
         else:
             view[name] = view[name].to(device, non_blocking=True)
 
-    with torch.cuda.amp.autocast(enabled=False):
+    with torch.amp.autocast(device_type="cuda", enabled=False):
         state_feat, state_pos, init_state_feat, mem, init_mem = state_args
         pred, _ = model.inference_step(
             view, state_feat, state_pos, init_state_feat, mem, init_mem
@@ -279,7 +279,7 @@ def inference_recurrent(groups, model, device, verbose=True):
     if verbose:
         print(f">> Inference with model on {len(groups)} image/raymaps")
 
-    with torch.cuda.amp.autocast(enabled=False):
+    with torch.amp.autocast(device_type="cuda", enabled=False):
         preds, batch, state_args = model.forward_recurrent(
             groups, device, ret_state=True
         )

--- a/extern/CUT3R/src/dust3r/patch_embed.py
+++ b/extern/CUT3R/src/dust3r/patch_embed.py
@@ -18,12 +18,10 @@ def get_patch_embed(patch_embed_cls, img_size, patch_size, enc_embed_dim, in_cha
 class PatchEmbedDust3R(PatchEmbed):
     def forward(self, x, **kw):
         B, C, H, W = x.shape
-        assert (
-            H % self.patch_size[0] == 0
-        ), f"Input image height ({H}) is not a multiple of patch size ({self.patch_size[0]})."
-        assert (
-            W % self.patch_size[1] == 0
-        ), f"Input image width ({W}) is not a multiple of patch size ({self.patch_size[1]})."
+        pad_h = (self.patch_size[0] - H % self.patch_size[0]) % self.patch_size[0]
+        pad_w = (self.patch_size[1] - W % self.patch_size[1]) % self.patch_size[1]
+        if pad_h or pad_w:
+            x = torch.nn.functional.pad(x, (0, pad_w, 0, pad_h))
         x = self.proj(x)
         pos = self.position_getter(B, x.size(2), x.size(3), x.device)
         if self.flatten:
@@ -53,12 +51,10 @@ class ManyAR_PatchEmbed(PatchEmbed):
     def forward(self, img, true_shape):
         B, C, H, W = img.shape
 
-        assert (
-            H % self.patch_size[0] == 0
-        ), f"Input image height ({H}) is not a multiple of patch size ({self.patch_size[0]})."
-        assert (
-            W % self.patch_size[1] == 0
-        ), f"Input image width ({W}) is not a multiple of patch size ({self.patch_size[1]})."
+        pad_h = (self.patch_size[0] - H % self.patch_size[0]) % self.patch_size[0]
+        pad_w = (self.patch_size[1] - W % self.patch_size[1]) % self.patch_size[1]
+        if pad_h or pad_w:
+            img = torch.nn.functional.pad(img, (0, pad_w, 0, pad_h))
         assert true_shape.shape == (
             B,
             2,


### PR DESCRIPTION
## Summary
- ensure images are padded so their dimensions match the model patch size
- update deprecated `torch.cuda.amp.autocast` calls to `torch.amp.autocast`

## Testing
- `python -m py_compile extern/CUT3R/src/dust3r/patch_embed.py extern/CUT3R/src/dust3r/inference.py`


------
https://chatgpt.com/codex/tasks/task_e_687b8f72ce54832f8cff22f36238e8e6