### PR TITLE
Fix ray_map dimensions for CUT3R inference

### DIFF
--- a/extern/CUT3R/surfel_inference.py
+++ b/extern/CUT3R/surfel_inference.py
@@ -150,9 +150,9 @@ def prepare_input(
         "ray_map": torch.full(
                 (
                     images[i]["img"].shape[0],
-                    6,
                     images[i]["img"].shape[-2],
                     images[i]["img"].shape[-1],
+                    6,
                 ),
                 torch.nan,
             ),
@@ -506,9 +506,9 @@ def prepare_input_from_pil(
             "ray_map": torch.full(
                 (
                     imgs[i]["img"].shape[0],
-                    6,
                     imgs[i]["img"].shape[-2],
                     imgs[i]["img"].shape[-1],
+                    6,
                 ),
                 torch.nan,
             ),


### PR DESCRIPTION
## Summary
- correct ray_map initialization in `surfel_inference.py`

## Testing
- `python -m py_compile extern/CUT3R/surfel_inference.py`
- `python -m py_compile navigation.py app.py modeling/pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_687b944cd41c832f811f12895dba0b2f