### PR TITLE
Fix SVD precision issue on MPS

### DIFF
--- a/extern/CUT3R/cloud_opt/dust3r_opt/init_im_poses.py
+++ b/extern/CUT3R/cloud_opt/dust3r_opt/init_im_poses.py
@@ -262,6 +262,12 @@ def dict_to_sparse_graph(dic):
 
 
 def rigid_points_registration(pts1, pts2, conf):
+    """Wrapper around :func:`roma.rigid_points_registration` with type safety."""
+
+    pts1 = pts1.to(dtype=torch.float32)
+    pts2 = pts2.to(dtype=torch.float32)
+    conf = conf.to(dtype=torch.float32)
+
     R, T, s = roma.rigid_points_registration(
         pts1.reshape(-1, 3),
         pts2.reshape(-1, 3),
@@ -374,7 +380,9 @@ def align_multiple_poses(src_poses, target_poses):
         return torch.cat((poses[:, :3, 3], poses[:, :3, 3] + eps * poses[:, :3, 2]))
 
     R, T, s = roma.rigid_points_registration(
-        center_and_z(src_poses), center_and_z(target_poses), compute_scaling=True
+        center_and_z(src_poses).to(dtype=torch.float32),
+        center_and_z(target_poses).to(dtype=torch.float32),
+        compute_scaling=True,
     )
     # If scale is too small (near zero), set it to 1 to prevent numerical issues
     if abs(s) < 1e-6:

--- a/extern/CUT3R/cloud_opt/utils.py
+++ b/extern/CUT3R/cloud_opt/utils.py
@@ -245,6 +245,13 @@ def estimate_focal(pts3d_i, pp=None):
 
 
 def rigid_points_registration(pts1, pts2, conf):
+    """Wrapper around :func:`roma.rigid_points_registration` with type safety."""
+
+    # Ensure inputs are float32 to avoid half-precision errors on CPU/MPS
+    pts1 = pts1.to(dtype=torch.float32)
+    pts2 = pts2.to(dtype=torch.float32)
+    conf = conf.to(dtype=torch.float32)
+
     R, T, s = roma.rigid_points_registration(
         pts1.reshape(-1, 3),
         pts2.reshape(-1, 3),
@@ -411,7 +418,9 @@ def align_multiple_poses(src_poses, target_poses):
         return torch.cat((poses[:, :3, 3], poses[:, :3, 3] + eps * poses[:, :3, 2]))
 
     R, T, s = roma.rigid_points_registration(
-        center_and_z(src_poses), center_and_z(target_poses), compute_scaling=True
+        center_and_z(src_poses).to(dtype=torch.float32),
+        center_and_z(target_poses).to(dtype=torch.float32),
+        compute_scaling=True,
     )
     return s, R, T
 


### PR DESCRIPTION
## Summary
- prevent half precision tensors when calling `roma.rigid_points_registration`
- ensure pose alignment uses float32 to avoid MPS `linalg_svd_cpu` errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b99f11f54832f92fe6d5b8cfa4ecc